### PR TITLE
Prevent scrolling when closing modals

### DIFF
--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -398,7 +398,7 @@ EventHandler.on(document, EVENT_CLICK_DATA_API, SELECTOR_DATA_TOGGLE, function (
 
     EventHandler.one(target, EVENT_HIDDEN, () => {
       if (isVisible(this)) {
-        this.focus()
+        this.focus({ preventScroll: true })
       }
     })
   })


### PR DESCRIPTION
Prevent scrolling when re-focusing the modal-triggering element once the modal was hidden. Closes #35391.